### PR TITLE
fix: refactor video player component + fixing hero banners

### DIFF
--- a/src/components/render-asset.tsx
+++ b/src/components/render-asset.tsx
@@ -17,7 +17,6 @@ const RenderAsset: React.FC<{
 	videoPlayingAspectClasses?: string;
 	ignoreAspectRatio?: boolean;
 	videoRef?: React.RefObject<HTMLVideoElement>;
-	isVideoPlay?: boolean;
 }> = ({
 	url,
 	imageAlt,
@@ -31,8 +30,7 @@ const RenderAsset: React.FC<{
 	videoAspectClasses = "aspect-square lg:aspect-[16/10]",
 	videoPlayingAspectClasses = "aspect-video lg:aspect-[16/9]",
 	ignoreAspectRatio = false,
-	videoRef,
-	isVideoPlay
+	videoRef
 }) => {
 	const type = whatIsType(url);
 
@@ -65,7 +63,6 @@ const RenderAsset: React.FC<{
 				videoPlayingAspectClasses={videoPlayingAspectClasses}
 				ignoreAspectRatio={ignoreAspectRatio}
 				videoRef={videoRef}
-				isVideoPlay={isVideoPlay}
 			/>
 		);
 	}

--- a/src/components/video-player.tsx
+++ b/src/components/video-player.tsx
@@ -75,7 +75,7 @@ export default function VideoPlayer({
 		if (finalVideoRef?.current?.paused) {
 			setIsPlaying(false)
 		}
-	}, [finalVideoRef?.current?.paused])
+	}, [finalVideoRef?.current?.paused]);
 
 	useEffect(() => {
 		const videoElement = finalVideoRef.current;


### PR DESCRIPTION
hi @ilyas-muhammad i will reset branch main branch before @alif-firdaus fix anyting in video component and make [Backup](https://github.com/petaniweb-tech/studionarta/tree/main-backup) for that.

This PR will fix
- when the users try to play the video for the first time, the  video will play until the end, and then it will move to the next slide
- when the users try to play the video, and then pause the video, the paused video will last only for 3 seconds before it moves to the next slide
- when the users try to play the video, and pause the video, and resume the video, the video should also play until the end
- auto-pause video when user tries to slide


This PR exclude 
- when the user tries to play the video. that video will use a ratio 16:9 (Can't replicate)